### PR TITLE
Fix compatibility issues of Overviews 0 from AfranioMelo (Issue #111)

### DIFF
--- a/overviews/AfranioMelo/0-normal-data-eda.ipynb
+++ b/overviews/AfranioMelo/0-normal-data-eda.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "9007dd39",
    "metadata": {
     "_cell_guid": "b1076dfc-b9ad-4769-8c92-a6c4dae69d19",
@@ -42,6 +42,8 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
+    "color_cycle = plt.rcParams['axes.prop_cycle'].by_key()['color']\n",
     "\n",
     "import seaborn as sns\n",
     "import missingno"
@@ -250,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "d8ebc2f7",
    "metadata": {
     "papermill": {
@@ -277,21 +279,30 @@
    "source": [
     "%%time\n",
     "\n",
-    "EVENT = 0\n",
-    "\n",
     "PATH = os.path.join('..', '..', 'dataset', str(EVENT))\n",
     "\n",
     "if os.path.exists(PATH):\n",
     "    files = [f for f in os.listdir(PATH) if os.path.isfile(os.path.join(PATH, f))]\n",
     "\n",
-    "dfs = {}\n",
+    "columns_to_keep = list(tags.keys()) + ['class']\n",
     "\n",
+    "dfs = {}\n",
     "for file in files:\n",
+    "    df = pd.read_parquet(os.path.join(PATH, file), engine=\"pyarrow\")\n",
+    "    df = df.reindex(columns=columns_to_keep)\n",
     "    \n",
-    "    dfs[file[:-4]] = pd.read_csv(os.path.join(PATH, file), index_col = 0,\n",
-    "                     parse_dates = True).rename_axis(None)\n",
+    "    dfs[os.path.splitext(file)[0]] = df\n",
+    "\n",
+    "wells_numbers = []\n",
     "    \n",
-    "print('Data read!\\nNumber of instances: ',len(dfs))"
+    "for key in dfs.keys():\n",
+    "    if 'SIMULATED' in key or 'DRAWN' in key:\n",
+    "        continue\n",
+    "    else:\n",
+    "        wells_numbers.append(int(key[8:10]))\n",
+    "    \n",
+    "print('Data read!\\nNumber of instances: ',len(dfs))\n",
+    "print('Number of real instances: ',len(wells_numbers))"
    ]
   },
   {
@@ -459,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "659e41bc",
    "metadata": {
     "papermill": {
@@ -486,10 +497,10 @@
     "    for i in range(8):\n",
     "        ax[i].plot(data.iloc[:,i].values,c='k',linewidth=0.8)\n",
     "        for j in range(start_index,end_index2):\n",
-    "            loc = data.index.get_loc(dfs[instance_beginnings[j]].index[0])\n",
+    "            loc = data.index.get_indexer_for([dfs[instance_beginnings[j]].index[0]])[0]\n",
     "            ax[i].axvline(loc,ls='--',linewidth=0.6)\n",
     "        for j in index_beginnings_new_period[well]:\n",
-    "            loc = data.index.get_loc(dfs[instance_beginnings[j]].index[0])\n",
+    "            loc = data.index.get_indexer_for([dfs[instance_beginnings[j]].index[0]])[0]\n",
     "            ax[i].axvline(loc,c='r',linewidth=2)\n",
     "        ax[i].set_ylabel(i+1,rotation=0,fontsize=14)\n",
     "        ax[i].set_yticks([])\n",
@@ -641,7 +652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "606e8603",
    "metadata": {
     "papermill": {
@@ -737,7 +748,17 @@
    ],
    "source": [
     "for tag in reference_table.Tag:\n",
-    "    plot_tag(tag)"
+    "    fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "    for key in dfs:\n",
+    "        well = int(key[8:10])\n",
+    "        color = color_cycle[(well - 1) % len(color_cycle)]\n",
+    "        ax.plot(dfs[key][tag][::60].values, color=color, label=f'Well {well}', ls='', marker='.')\n",
+    "        ax.axhline(dfs[key][tag][::60].values.mean(), color=color, ls='--')\n",
+    "    handles, labels = ax.get_legend_handles_labels()\n",
+    "    by_label = dict(zip(labels, handles))\n",
+    "    ax.legend(by_label.values(), by_label.keys())\n",
+    "    ax.set_title(tag)\n",
+    "    plt.show()\n"
    ]
   },
   {


### PR DESCRIPTION
This PR updates **Overview 0**, originally developed by AfranioMelo, to ensure compatibility with version 2.0.0 of the 3W dataset, addressing [issue #111](https://github.com/petrobras/3W/issues/111).

Changes made:
- Added `color_cycle` variable for consistent color handling in plots.
- Updated data import to use Parquet files and retain only relevant columns.
- Fixed `plot_timeseries_well` by replacing `get_loc` with `get_indexer_for` to avoid index errors.
- Refactored the time series plotting loop to use `color_cycle directly`.



_______________________________________

By creating this pull request, I confirm that I have read and fully accept and agree with one of the **Petrobras' Contributor License Agreements (CLAs)**: 

* ICLA: [Individual Contributor License Agreement](../blob/main/clas/individual_cla.md) on behalf of **only yourself**;
* CCLA: [Corporate Contributor License Agreement](../blob/main/clas/corporate_cla.md) on behalf of **your employer**.

Our CLAs are based on the *Apache Software Foundation's CLAs*:

* ICLA: [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
* CCLA: [Corporate Contributor License Agreement](https://www.apache.org/licenses/cla-corporate.pdf)