### PR TITLE
[DRAFT] Github workflow to generate `uv.lock`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,11 +32,8 @@ jobs:
       - name: Make helper scripts executable
         run: chmod +x bin/lint
 
-      - name: Create venv
-        run: uv venv .venv
-
       - name: Install package with dev extras
-        run: uv pip install -e .[dev]
+        run: uv sync --locked --extra dev
 
       - name: Run lint
         run: uv run ./bin/lint
@@ -76,11 +73,8 @@ jobs:
       - name: Make helper scripts executable
         run: chmod +x bin/test
 
-      - name: Create venv
-        run: uv venv .venv
-
       - name: Install package with dev extras
-        run: uv pip install -e .[dev]
+        run: uv sync --locked --extra dev
 
       - name: Testing
         run: uv run ./bin/test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,16 +27,22 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-caching: true
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Show versions
+        run: |
+          python --version
+          uv --version
 
       - name: Make helper scripts executable
         run: chmod +x bin/lint
 
-      - name: Install package with dev extras
+      - name: Install locked dependencies with dev extras
         run: uv sync --locked --extra dev
 
       - name: Run lint
-        run: uv run ./bin/lint
+        run: uv run --no-sync ./bin/lint
 
   test:
     runs-on: ubuntu-latest
@@ -63,7 +69,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-caching: true
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Show versions
         run: |
@@ -73,11 +80,11 @@ jobs:
       - name: Make helper scripts executable
         run: chmod +x bin/test
 
-      - name: Install package with dev extras
+      - name: Install locked dependencies with dev extras
         run: uv sync --locked --extra dev
 
       - name: Testing
-        run: uv run ./bin/test
+        run: uv run --no-sync ./bin/test
 
       - name: Upload coverage to Coveralls
         if: matrix.python-version == '3.10'


### PR DESCRIPTION

With this PR, these are the workflows we aim to have:

1. Update `uv.lock` file 
    - **Workflow:** `update-uv-lock.yml`
    - **Triggered on:** any package change is noted in `pyproject.toml`
        
2. Execute lint & pytest using `uv.lock` 
    - **Workflow:** `tests.yml`
    - **Triggered on:** PR & Pushes to main branch
        
3. Build and publish package in PyPI 
    - **Workflow:** `publish.yml`
    - **Triggered on:** pushes to main branch that includes changes to the `pyproject.toml`
    - Compares the version field in `pyproject.toml` between the current and previous commit. If unchanged, it skips the package publication in PyPi.

## Changes: 

In the existing `tests.yml` workflow, we forced the testing package to use the `uv.lock` by installing the package with:
```python
uv sync --locked --extra dev
```
Note the `--locked` ensures the install fails if `uv.lock` is out of sync with `pyproject.toml`, rather than silently re-resolving.

-----

By creating this pull request, I confirm that I have read and fully accept and agree with one of the **Petrobras' Contributor License Agreements (CLAs)**: 

* ICLA: [Individual Contributor License Agreement](../blob/main/clas/individual_cla.md) on behalf of **only yourself**;
* CCLA: [Corporate Contributor License Agreement](../blob/main/clas/corporate_cla.md) on behalf of **your employer**.

Our CLAs are based on the *Apache Software Foundation's CLAs*:

* ICLA: [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
* CCLA: [Corporate Contributor License Agreement](https://www.apache.org/licenses/cla-corporate.pdf)
