### PR TITLE
Configure Git attributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+bin/* text eol=lf


### PR DESCRIPTION
## Summary

Add a `.gitattributes` file to standardize text file handling and line endings across different operating systems.

## Changes

* Enable automatic text file detection and line-ending normalization.
* Enforce LF line endings for files under the `bin/` directory.

## Configuration

```gitattributes
* text=auto
bin/* text eol=lf
```


----
By creating this pull request, I confirm that I have read and fully accept and agree with one of the **Petrobras' Contributor License Agreements (CLAs)**: 

* ICLA: [Individual Contributor License Agreement](../blob/main/clas/individual_cla.md) on behalf of **only yourself**;
* CCLA: [Corporate Contributor License Agreement](../blob/main/clas/corporate_cla.md) on behalf of **your employer**.

Our CLAs are based on the *Apache Software Foundation's CLAs*:

* ICLA: [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
* CCLA: [Corporate Contributor License Agreement](https://www.apache.org/licenses/cla-corporate.pdf)
