### PR TITLE
Add DOIs to the two Vargas paper.bib entries

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -32,7 +32,8 @@ journal = {Journal of Petroleum Science and Engineering},
 volume = {181},
 pages = {106223},
 year = {2019},
-author = {Ricardo Emanuel Vaz Vargas and Celso José Munaro and Patrick Marques Ciarelli and André Gonçalves Medeiros and Bruno Guberfain do Amaral and Daniel Centurion Barrionuevo and Jean Carlos Dias de Araújo and Jorge Lins Ribeiro and Lucas Pierezan Magalhães}
+author = {Ricardo Emanuel Vaz Vargas and Celso José Munaro and Patrick Marques Ciarelli and André Gonçalves Medeiros and Bruno Guberfain do Amaral and Daniel Centurion Barrionuevo and Jean Carlos Dias de Araújo and Jorge Lins Ribeiro and Lucas Pierezan Magalhães},
+doi = {10.1016/j.petrol.2019.106223}
 }
 
 
@@ -42,7 +43,8 @@ journal = {Journal of Petroleum Science and Engineering},
 volume = {218},
 pages = {110983},
 year = {2022},
-author = {André Paulo Ferreira Machado and Ricardo Emanuel Vaz Vargas and Patrick Marques Ciarelli and Celso Jose Munaro}
+author = {André Paulo Ferreira Machado and Ricardo Emanuel Vaz Vargas and Patrick Marques Ciarelli and Celso Jose Munaro},
+doi = {10.1016/j.petrol.2022.110983}
 }
 
 


### PR DESCRIPTION
By creating this pull request, I confirm that I have read and fully accept and agree with one of the **Petrobras' Contributor License Agreements (CLAs)**: 

* ICLA: [Individual Contributor License Agreement](../blob/main/clas/individual_cla.md) on behalf of **only yourself**;
* CCLA: [Corporate Contributor License Agreement](../blob/main/clas/corporate_cla.md) on behalf of **your employer**.

Our CLAs are based on the *Apache Software Foundation's CLAs*:

* ICLA: [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
* CCLA: [Corporate Contributor License Agreement](https://www.apache.org/licenses/cla-corporate.pdf)

---

Fixes #218.

Adds the `doi` field to `VARGAS2019` and `Vargas2022` in `paper/paper.bib`. Both check out on Crossref by title, first author and year.

On `cosmetic_improvements` per the contributing guide.
